### PR TITLE
max open files limit for kube-proxy

### DIFF
--- a/units/kube-proxy.service
+++ b/units/kube-proxy.service
@@ -3,6 +3,7 @@ Description=Kubernetes Proxy
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
+LimitNOFILE=50000
 ExecStartPre=/bin/bash -c '/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/_K8S_VERSION_/bin/linux/amd64/kube-proxy'
 ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
 ExecStart=/opt/bin/kube-proxy \


### PR DESCRIPTION
I bumped into the max open files limit on CoreOS (and probably it would be a problem on other distros as well), because during a siege/ab test the 1024 file descriptors weren't enough to handle the incoming requests.
