### PR TITLE
Use the node_name base as a tag on the nodes so that external load

### DIFF
--- a/1-bootstrap_cluster.sh
+++ b/1-bootstrap_cluster.sh
@@ -42,14 +42,14 @@ gcloud compute routes create ip-10-222-1-1-$master_name --project=$project \
 #
 
 # create nodes
-#  by defaul 3 nodes get created, update node_count in settinga file if you want a different number of nodes
+#  by default 3 nodes get created, update node_count in settings file if you want a different number of nodes
 for (( i=1; i<=$node_count; i++ ))
 do
     gcloud compute instances create $node_name-$i \
      --project=$project --image=$image --image-project=coreos-cloud \
      --boot-disk-type=pd-standard --boot-disk-size=50 --zone=$zone \
      --machine-type=$node_machine_type --metadata-from-file user-data=./cloud-config/node.yaml \
-     --can-ip-forward --tags=k8s-cluster,k8s-nodes
+     --can-ip-forward --tags="k8s-cluster,${node_name}"
 done
 #
 


### PR DESCRIPTION
balancers can be created.

Also fix a couple small typos.

This has caused pain for a couple different users, in both https://github.com/kubernetes/kubernetes/issues/13073 and http://stackoverflow.com/questions/31832713/kubernetes-1-0-1-external-load-balancer-on-gce-with-coreos
