### PR TITLE
generate secret for default ServiceAccount

### DIFF
--- a/units/kube-apiserver.service
+++ b/units/kube-apiserver.service
@@ -18,7 +18,10 @@ ExecStart=/opt/bin/kube-apiserver \
  --cloud_provider=gce \
  --cors_allowed_origins=.* \
  --logtostderr=true \
- --runtime_config=api/v1
+ --runtime_config=api/v1 \
+ --admission-control=ServiceAccount \
+ --service_account_key_file=/var/run/kubernetes/apiserver.key \
+ --service_account_lookup=false
 
 Restart=always
 RestartSec=10

--- a/units/kube-controller-manager.service
+++ b/units/kube-controller-manager.service
@@ -10,7 +10,8 @@ ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
 ExecStart=/opt/bin/kube-controller-manager \
  --master=127.0.0.1:8080 \
  --cloud_provider=gce \
- --logtostderr=true
+ --logtostderr=true \
+ --service-account-private-key-file="/var/run/kubernetes/apiserver.key"
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
I have modified the systemd unit files of the apiserver and controller-manager so that they generate the secret for the "default" service account. This way pods depending on the API, like heapster, can work.
