### PR TITLE
Making explicit the need for ssh-agent to run the second script

### DIFF
--- a/2-get_k8s_fleet_etcd.sh
+++ b/2-get_k8s_fleet_etcd.sh
@@ -2,7 +2,10 @@
 
 ssh-add ~/.ssh/google_compute_engine &>/dev/null
 
-# Install/update etcdctl, fleetctl and kubectl
+if [ $? != 0  ]; then
+  echo "Your ssh-agent isn't running -- please start it and run this script again."
+  exit 2
+fi
 
 # fetch from settings file
 project=$(cat settings | grep project= | head -1 | cut -f2 -d"=")

--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ cd coreos-multi-node-k8s-gce
 ````
 * edit `settings` and set `project and zone`, the rest of settings you can adjust by your requirements if you need to.
 
+
+### Start ssh-agent as it is used extensively by this script
+
+Confirm your ssh-agent is running.  Run the following command.  If you see the error message then it is not running.
+
+````
+$ ssh-add -l
+Could not open a connection to your authentication agent.
+````
+
+Start it up.  Run the command ssh-agent.  You should see somthing simlar to the following.
+
+````
+$ ssh-agent
+SSH_AUTH_SOCK=/tmp/ssh-ztSdihLxClVL/agent.24475; export SSH_AUTH_SOCK;
+SSH_AGENT_PID=24476; export SSH_AGENT_PID;
+echo Agent pid 24476;
+````
+
+Cut and paste the three lines the command output and paste back into the terminal you're using to run the kubernetes commnands.  We can then do a quick test to confirm that we're running `ssh-agent` as we expect.
+
+````
+$ ssh-add -l
+The agent has no identities.
+````
+
+`ssh-agent` is a whole other category of software.  You can [look more into it here.](http://rabexc.org/posts/pitfalls-of-ssh-agents)
+
 ### Bootstrap Kubernetes Cluster and install local clients
 
 * To bootstrap CoreOS cluster in GCE run:


### PR DESCRIPTION
`ssh-agent` being active is implicitly required by the second script.  I made it explicit where we exit immediately with a descriptive error if we can't `ssh-add` the compute engine key. 

I also added a section to `README.md` to address `ssh-agent` despite it being way outside of the script scope.  I'm not 100% sold on the README half of this -- probably should just google, but I wanted to be thorough.
